### PR TITLE
[CD-171] 검색 페이지 구현

### DIFF
--- a/front/lib/main.dart
+++ b/front/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'firebase_options.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:capstone/constants/color.dart' as colors;
 void main() async {
   await dotenv.load(fileName: '.env');
   await Firebase.initializeApp(
@@ -20,7 +21,8 @@ class MyApp extends StatelessWidget {
     return GetMaterialApp(
       title: 'Capstone',
       theme: ThemeData(
-        fontFamily: 'KoddiUDOnGothic'
+        fontFamily: 'KoddiUDOnGothic',
+        scaffoldBackgroundColor: colors.bgrBrightColor
       ),
       initialRoute: '/bottom_navigation',
       getPages: [

--- a/front/lib/model/load_data.dart
+++ b/front/lib/model/load_data.dart
@@ -51,14 +51,20 @@ class LoadData {
     }
   }
 
-  Stream<List<RecordModel>> readUserPracticeRecord(String route) {
+  Stream<List<RecordModel>> readUserPracticeRecord(String scriptType) {
     return firestore
           .collection('user')
           .doc('mg')
-          .collection('${route}_practice')
+          .collection('${scriptType}_practice')
           .snapshots()
           .map((snapshot) => snapshot.docs
               .map((doc) => RecordModel.fromDocument(doc: doc))
               .toList());
+  }
+
+  Future<RecordModel> readRecordDocument(String scriptType, String documentId) async {
+    DocumentSnapshot<Map<String, dynamic>> recordDocument = 
+      await firestore.collection('user').doc('mg').collection('${scriptType}_practice').doc(documentId).get();
+    return RecordModel.fromDocument(doc: recordDocument);
   }
 }

--- a/front/lib/model/load_data.dart
+++ b/front/lib/model/load_data.dart
@@ -51,6 +51,28 @@ class LoadData {
     }
   }
 
+  Stream<List<ScriptModel>> searchExampleScript(String? query) {
+    return firestore
+      .collection('example_script')
+      .snapshots()
+      .map((snapshot) => snapshot.docs
+        .where((doc) => doc['title'].toString().contains(query ?? ''))
+        .map((doc) => ScriptModel.fromDocument(doc: doc))
+        .toList());
+  }
+
+  Stream<List<ScriptModel>> searchUserScript(String? query) {
+    return firestore
+        .collection('user_script')
+        .doc('mg')
+        .collection('script')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+          .where((doc) => doc['title'].toString().contains(query ?? ''))
+          .map((doc) => ScriptModel.fromDocument(doc: doc))
+          .toList());
+  }
+
   Stream<List<RecordModel>> readUserPracticeRecord(String scriptType) {
     return firestore
           .collection('user')

--- a/front/lib/model/script.dart
+++ b/front/lib/model/script.dart
@@ -2,43 +2,35 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class ScriptModel {
   String? id;
-  //final String uid;
   final String title;
   final String category;
   final List<String> content;
   final Timestamp createdAt;
-  //List<String> keyword;
   
   ScriptModel({
       this.id,
-      //required this.uid,
       required this.title,
       required this.category,
       required this.content,
       required this.createdAt,
-      //required this.keyword
   });
 
   ScriptModel.fromDocument({required DocumentSnapshot<Map<String, dynamic>> doc})
       : id = doc.id,
-        //uid = doc.data()!['uid'],
         title = doc.data()!['title'],
         category = doc.data()!['category'],
-        content = doc.data()!['content'].cast<String>(),
+        content = doc.data()!['content'] == null
+          ? []
+          : doc.data()!['content'].cast<String>(),
         createdAt = doc.data()!['createdAt'];
-        //keyword = doc.data()!['keyword'] == null
-        //    ? null
-        //    : doc.data()!['keyword'].cast<String>();
         
 
   Map<String, dynamic> convertToDocument() {
     return {
-      //'uid': uid,
       'title': title,
       'category': category,
       'content': content,
       'createdAt': createdAt,
-      //'keyword' : keyword
     };
   }
 }

--- a/front/lib/screen/record/record_taps.dart
+++ b/front/lib/screen/record/record_taps.dart
@@ -28,7 +28,7 @@ class RecordTabsState extends State<RecordTabs> with SingleTickerProviderStateMi
   @override
   Widget build(BuildContext context){
     return Scaffold(
-      appBar: tapBar(_tabController),
+      appBar: listTapBar(_tabController, 'record'),
       body: TabBarView(
         controller: _tabController,
         children: [

--- a/front/lib/screen/script/create_user_script/adjust_user_script.dart
+++ b/front/lib/screen/script/create_user_script/adjust_user_script.dart
@@ -22,7 +22,6 @@ class AdjustUserScript extends StatefulWidget {
 
   final String title;
   final String category;
-  final Color backgroundColor = colors.bgrBrightColor;
 
   @override
   State<AdjustUserScript> createState() => _AdjustUserScriptState();
@@ -66,7 +65,6 @@ class _AdjustUserScriptState extends State<AdjustUserScript> {
       body: Stack(
               children: [
                 Container(
-                  color: widget.backgroundColor,
                   padding: const EdgeInsets.fromLTRB(20, 20, 20, 20),
                   child: ListView(
                     children: [

--- a/front/lib/screen/script/create_user_script/create_user_script.dart
+++ b/front/lib/screen/script/create_user_script/create_user_script.dart
@@ -17,8 +17,6 @@ import 'package:get/get.dart';
 class CreateUserScript extends StatefulWidget {
   const CreateUserScript({Key? key}) : super(key: key);
 
-  final Color backgroundColor = colors.bgrBrightColor;
-
   @override
   State<CreateUserScript> createState() => _CreateUserScriptState();
 }
@@ -64,15 +62,12 @@ class _CreateUserScriptState extends State<CreateUserScript> {
       appBar: basicAppBar(title: '나만의 대본 만들기'),
       body: Stack(
         children: [
-          Container(
-            color: widget.backgroundColor,
-                child: Column(
-                  children: [
-                    TitleSection(titleController: _title, formKey: _titleKey),
-                    CategorySection(onCategorySelected: _handleCategorySelected),
-                    ContentSection(contentController: _content, formKey: _contentKey)
-                ])
-          ),
+          Column(
+            children: [
+              TitleSection(titleController: _title, formKey: _titleKey),
+              CategorySection(onCategorySelected: _handleCategorySelected),
+              ContentSection(contentController: _content, formKey: _contentKey)
+          ]),
           bottomButtons(
             MediaQuery.of(context).size.width, 
             outlinedRoundedRectangleButton('AI로 생성하기', () {

--- a/front/lib/screen/script/create_user_script/create_user_script.dart
+++ b/front/lib/screen/script/create_user_script/create_user_script.dart
@@ -37,6 +37,9 @@ class _CreateUserScriptState extends State<CreateUserScript> {
   }
 
   void createScriptByGpt(String title, String category) async {
+      setState(() {
+        _content.text = 'AI로 대본을 생성하고 있습니다. 잠시만 기다려주세요.';
+      });
       await GptController().createScript(title, category).then((script) {
         setState(() {
           _content.text = script;

--- a/front/lib/screen/script/script_detail.dart
+++ b/front/lib/screen/script/script_detail.dart
@@ -1,5 +1,8 @@
 import 'package:capstone/constants/color.dart' as colors;
+import 'package:capstone/model/load_data.dart';
+import 'package:capstone/model/record.dart';
 import 'package:capstone/model/script.dart';
+import 'package:capstone/screen/record/record_detail.dart';
 import 'package:capstone/widget/script/script_content_block.dart';
 import 'package:capstone/widget/basic_app_bar.dart';
 import 'package:capstone/widget/fully_rounded_rectangle_button.dart';
@@ -11,10 +14,12 @@ import 'package:get/get.dart';
 
 class ScriptDetail extends StatefulWidget {
   const ScriptDetail({Key? key,
-    required this.script
+    required this.script,
+    required this.scriptType
   }) : super(key: key);
 
   final ScriptModel script;
+  final String scriptType;
   final Color backgroundColor = colors.bgrBrightColor;
 
   @override
@@ -22,6 +27,7 @@ class ScriptDetail extends StatefulWidget {
 }
 
 class _ScriptDetailState extends State<ScriptDetail> {
+  LoadData loadData = LoadData();
 
   Text _buildCategory(String category){
     return Text(
@@ -48,7 +54,6 @@ class _ScriptDetailState extends State<ScriptDetail> {
       ),
     );
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -92,13 +97,25 @@ class _ScriptDetailState extends State<ScriptDetail> {
                     child: Container(
                       padding: const EdgeInsets.fromLTRB(20, 5, 20, 5),
                       child: false ?
-                      fullyRoundedRectangleButton(colors.textColor, '연습하기', () {})
+                      fullyRoundedRectangleButton(colors.textColor, '연습하기', () {
+                        Get.to(() => SelectPractice(
+                          script: widget.script,
+                          tapCloseButton: () { Get.back(); },
+                        ));
+                      })
                       : Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
                             Container(
-                                width: width * 0.4,
-                                child: outlinedRoundedRectangleButton('기록보기', () {})),
+                              width: width * 0.4,
+                              child: outlinedRoundedRectangleButton('기록보기', () async {
+                                RecordModel record = await loadData.readRecordDocument(widget.scriptType, widget.script.id!);
+                                Get.to(() => RecordDetail(
+                                  script: widget.script, 
+                                  record: record
+                                ));
+                              })
+                            ),
                             Container(
                               width: width * 0.4,
                               child: fullyRoundedRectangleButton(colors.buttonColor, '연습하기', () {

--- a/front/lib/screen/script/script_detail.dart
+++ b/front/lib/screen/script/script_detail.dart
@@ -20,7 +20,6 @@ class ScriptDetail extends StatefulWidget {
 
   final ScriptModel script;
   final String scriptType;
-  final Color backgroundColor = colors.bgrBrightColor;
 
   @override
   State<ScriptDetail> createState() => _ScriptDetailState();
@@ -60,11 +59,10 @@ class _ScriptDetailState extends State<ScriptDetail> {
     var width = MediaQuery.of(context).size.width;
 
     return Scaffold(
-        appBar: basicAppBar(backgroundColor: widget.backgroundColor, title: ''),
+        appBar: basicAppBar(backgroundColor: colors.bgrBrightColor, title: ''),
         body: Stack(
               children: [
                 Container(
-                  color: widget.backgroundColor,
                   padding: const EdgeInsets.fromLTRB(20, 5, 20, 20),
                   child: ListView(
                     children: [

--- a/front/lib/screen/script/script_list.dart
+++ b/front/lib/screen/script/script_list.dart
@@ -42,12 +42,12 @@ class _ScriptListState extends State<ScriptList> {
               ),
               widget.index == 0 ?
                 Expanded(
-                  child: readScripts(loadData.readExampleScripts(selectedCategoryValue))
+                  child: readScripts(loadData.readExampleScripts(selectedCategoryValue), 'example')
                 )
                 : Expanded(
                     child: Stack(
                       children:[
-                        readScripts(loadData.readUserScripts(selectedCategoryValue)),
+                        readScripts(loadData.readUserScripts(selectedCategoryValue), 'user'),
                         Positioned(
                           bottom: 2,
                           left: MediaQuery.of(context).size.width * 0.05,

--- a/front/lib/screen/script/script_taps.dart
+++ b/front/lib/screen/script/script_taps.dart
@@ -28,7 +28,7 @@ class ScriptTabsState extends State<ScriptTabs> with SingleTickerProviderStateMi
   @override
   Widget build(BuildContext context){
     return Scaffold(
-      appBar: tapBar(_tabController),
+      appBar: listTapBar(_tabController, 'script'),
       body: TabBarView(
           controller: _tabController,
           children: [

--- a/front/lib/screen/search/search_script.dart
+++ b/front/lib/screen/search/search_script.dart
@@ -1,0 +1,74 @@
+import 'package:capstone/screen/search/search_taps.dart';
+import 'package:flutter/material.dart';
+import 'package:capstone/constants/color.dart' as colors;
+import 'package:get/get.dart';
+
+class SearchScript extends StatefulWidget {
+  const SearchScript({Key? key}) : super(key: key);
+
+  @override
+  State<SearchScript> createState() => _SearchScriptState();
+}
+
+class _SearchScriptState extends State<SearchScript> {
+  final TextEditingController query = TextEditingController();
+
+  IconButton backToPreviousPage() {
+    return IconButton(
+      icon: const Icon(
+        Icons.arrow_back_rounded, 
+        color: colors.blockColor
+      ),
+      onPressed: () => Get.back(),
+    );
+  }
+
+  Flexible keywordSection() {
+    return Flexible(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(0, 0, 20, 0),
+        child: TextFormField(
+          onChanged: (text) {
+            setState(() {});
+          },
+          controller: query,
+          maxLines: 1,
+          decoration: InputDecoration(
+            labelText: '검색할 키워드를 입력해주세요.',
+            floatingLabelBehavior: FloatingLabelBehavior.never,
+            fillColor: colors.blockColor,
+            filled: true,
+            labelStyle: const TextStyle(
+              color: colors.textColor,
+              fontSize: 12,
+              fontWeight: FontWeight.w500),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(28),
+              borderSide: BorderSide.none),
+          ))),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        color: colors.bgrDarkColor,
+        child: Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+              width: MediaQuery.of(context).size.width,
+              child: Row(
+                children: [
+                  backToPreviousPage(),
+                  keywordSection()
+              ])
+            ),
+            Flexible(
+              child: SearchTabs(query: query.text),
+            )
+        ])
+    ));
+  }
+}

--- a/front/lib/screen/search/search_taps.dart
+++ b/front/lib/screen/search/search_taps.dart
@@ -1,0 +1,54 @@
+import 'package:capstone/widget/script/read_script.dart';
+import 'package:capstone/widget/tap_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:capstone/model/load_data.dart';
+import 'package:capstone/constants/color.dart' as colors;
+
+class SearchTabs extends StatefulWidget{
+  const SearchTabs({
+    Key? key,
+    required this.query
+  }) : super(key: key);
+
+  final String? query;
+  @override    
+  SearchTabsState createState() => SearchTabsState();
+}
+
+class SearchTabsState extends State<SearchTabs> with SingleTickerProviderStateMixin {   
+  final LoadData loadData = LoadData();
+  late TabController _tabController;
+
+  @override    
+  void initState(){        
+    super.initState();            
+    _tabController = TabController(vsync: this, length: 2);    
+    setState(() {});
+  }        
+
+  @override    
+  void dispose(){        
+    _tabController.dispose();        
+    super.dispose();    
+  }    
+
+  @override
+  Widget build(BuildContext context){
+    return Scaffold(
+      appBar: searchTapBar(_tabController),
+      body: Container(
+        color: colors.bgrDarkColor,
+        padding: const EdgeInsets.only(left: 35),
+        child: TabBarView(
+          controller: _tabController,
+          children: [
+            widget.query == ''
+              ? Container()
+              : readScripts(loadData.searchExampleScript(widget.query), 'example'),
+            widget.query == ''
+              ? Container()
+              : readScripts(loadData.searchUserScript(widget.query), 'user'),
+      ])
+    ));
+  }
+}

--- a/front/lib/screen/setting/setting.dart
+++ b/front/lib/screen/setting/setting.dart
@@ -2,7 +2,6 @@ import 'package:capstone/widget/basic_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:capstone/constants/color.dart' as colors;
 import 'package:capstone/constants/route.dart' as routes;
-import 'package:get/get.dart';
 
 class Setting extends StatelessWidget {
   const Setting({Key? key}) : super(key: key);
@@ -13,7 +12,6 @@ class Setting extends StatelessWidget {
       appBar: basicAppBar(title: '설정'),
       body: Container(
         padding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
-        color: colors.bgrBrightColor,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: routes.settingItems.map((item) =>

--- a/front/lib/widget/record/read_record_script.dart
+++ b/front/lib/widget/record/read_record_script.dart
@@ -7,9 +7,9 @@ import 'package:multiple_stream_builder/multiple_stream_builder.dart';
 
 LoadData loadData = LoadData();
 
-Widget readRecordScripts(dynamic streamFunc, String route){
+Widget readRecordScripts(dynamic streamFunc, String scriptType){
     return StreamBuilder2<List<ScriptModel>, List<RecordModel>>(
-        streams: StreamTuple2(streamFunc, loadData.readUserPracticeRecord(route)),
+        streams: StreamTuple2(streamFunc, loadData.readUserPracticeRecord(scriptType)),
         builder: (context, snapshots) {
           if(snapshots.snapshot1.hasData & snapshots.snapshot2.hasData){
             List<ScriptModel>? scriptList = snapshots.snapshot1.data;
@@ -19,7 +19,7 @@ Widget readRecordScripts(dynamic streamFunc, String route){
                 itemBuilder: (_, index) {
                   for(int idx=0; idx<scriptList!.length; idx++){
                     if(recordList[index].id == scriptList[idx].id) {
-                      return scriptListTile(context, scriptList[idx], 'record', record: recordList[index]);
+                      return scriptListTile(context, scriptList[idx], 'record', scriptType, record: recordList[index]);
                     }
                   }
                   return Container();

--- a/front/lib/widget/script/read_script.dart
+++ b/front/lib/widget/script/read_script.dart
@@ -2,7 +2,7 @@ import 'package:capstone/model/script.dart';
 import 'package:capstone/widget/script/script_list_tile.dart';
 import 'package:flutter/material.dart'; 
  
- Widget readScripts(dynamic streamFunc){
+ Widget readScripts(dynamic streamFunc, String scriptType){
     return StreamBuilder<List<ScriptModel>>(
         stream: streamFunc,
         builder: (context, snapshots) {
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
                 shrinkWrap: true,
                 itemBuilder: (_, index) {
                   ScriptModel script = snapshots.data![index];
-                  return scriptListTile(context, script, 'script');
+                  return scriptListTile(context, script, 'script', scriptType);
                 });
         } else {
           return const SelectionArea(

--- a/front/lib/widget/script/script_list_tile.dart
+++ b/front/lib/widget/script/script_list_tile.dart
@@ -62,13 +62,13 @@ Text _buildPrecision(int? precision){
   );
 }
 
-Widget scriptListTile(BuildContext context, ScriptModel script, String route, {RecordModel? record}) {
+Widget scriptListTile(BuildContext context, ScriptModel script, String route, String scriptType, {RecordModel? record}) {
   return GestureDetector(
       onTap: () {
         HapticFeedback.lightImpact();
         route == 'record' ?
           Get.to(() => RecordDetail(script: script, record: record))
-          : Get.to(() => ScriptDetail(script: script));
+          : Get.to(() => ScriptDetail(script: script, scriptType: scriptType));
       },
       child: Stack(
         children: [

--- a/front/lib/widget/tap_bar.dart
+++ b/front/lib/widget/tap_bar.dart
@@ -1,5 +1,7 @@
+import 'package:capstone/screen/search/search_script.dart';
 import 'package:flutter/material.dart';
 import 'package:capstone/constants/color.dart' as colors;
+import 'package:get/get.dart';
 
 final List<Tab> _tabs = [
     const Tab(
@@ -24,7 +26,48 @@ final List<Tab> _tabs = [
     )
   ];
 
-  PreferredSize tapBar(TabController tabController) {
+  IconButton moveToSearchPage() {
+    return IconButton(
+      icon: const Icon(
+        Icons.search_rounded, 
+        color: colors.blockColor
+      ), 
+      onPressed: () { Get.to(() => const SearchScript()); }
+    );
+  }
+
+  PreferredSize listTapBar(TabController tabController, String route) {
+    return PreferredSize(
+      preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: colors.bgrDarkColor,
+          padding: const EdgeInsets.fromLTRB(0, 20, 10, 0),
+          child: Row(
+            children: [
+              Expanded(
+                child: TabBar(
+                  controller: tabController,
+                  labelColor: colors.exampleScriptColor,
+                  unselectedLabelColor: colors.blockColor,
+                  dividerColor: colors.bgrDarkColor,
+                  indicatorColor: Colors.transparent,
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.start, 
+                  labelPadding: const EdgeInsets.only(left: 20),
+                  tabs: _tabs.map((label) => Container(
+                      child: label,
+                  )).toList(),
+                )
+              ),
+              route == 'script'
+                ? moveToSearchPage()
+                : Container()
+          ])
+        )
+    );
+  }        
+
+  PreferredSize searchTapBar(TabController tabController) {
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
       child: AppBar(
@@ -34,14 +77,13 @@ final List<Tab> _tabs = [
           labelColor: colors.exampleScriptColor,
           unselectedLabelColor: colors.blockColor,
           dividerColor: colors.bgrDarkColor,
-          indicatorColor: Colors.transparent,
-          isScrollable: true,
-          tabAlignment: TabAlignment.start, 
-          labelPadding: const EdgeInsets.only(left: 20),
+          indicatorColor: colors.exampleScriptColor,
+          tabAlignment: TabAlignment.fill,
           tabs: _tabs.map((label) => Container(
               child: label,
           )).toList(),
-        ))
+        )
+        )
     );
   }        
 


### PR DESCRIPTION
## Feature Description
스크립트 리스트 상단바에 돋보기 아이콘 추가해 검색 페이지 연결했습니다.
사용자가 입력한 텍스트가 제목에 포함되어있으면, 해당 스크립트가 리턴됩니다.
<img src = "https://github.com/kookmin-sw/capstone-2024-08/assets/66138381/a0c6b623-bde9-47f7-a52e-e1713c4f3088" width="50%">
<img src = "https://github.com/kookmin-sw/capstone-2024-08/assets/66138381/08033b30-5011-4cdc-a677-960728bd37bf" width="50%">
<img src = "https://github.com/kookmin-sw/capstone-2024-08/assets/66138381/67480692-3862-458f-8eae-04608ae4d2a3" width="50%">

firebase는 text search를 제공하지않고, 무료로 사용 가능한 text search 라이브러리도 없습니다.
그래서 필터링으로 검색 기능을 직접 구현했는데, 대량의 데이터에 대해서는 적합하지 않은 방식입니다. 
추후 앱스토어 릴리즈하게 된다면, 이 부분에 대해 다시 논의가 필요할 것 같습니다. 

## Tasks to Complete
- [x] 검색 페이지 구현
- [x] 스크립트 리스트 상단바에 검색 페이지 연결

## Additional Resources (Optional)
