### PR TITLE
Chore: 사용자 대본 내용 조정 페이지 버그 수정 & 텍스트 입력 unfocus 추가 

### DIFF
--- a/front/lib/constants/text.dart
+++ b/front/lib/constants/text.dart
@@ -39,6 +39,7 @@ Map<String, double> getUserProgressValues = {
 
 Map<String, String> warningMessage = {
   'category': '카테고리는 비워둘 수 없습니다. \n카테고리를 선택해주세요.',
+  'content': '비어있는 문장이 있습니다. 내용을 작성하거나 삭제해주세요.',
   'getUserVoice': '음성 녹음을 완료하지 않았습니다. \n녹음을 완료해주세요',
   'logout': '로그아웃 하시겠습니까?',
   'deleteUser': '서비스를 탈퇴 하시겠습니까?\n탈퇴 시, 계정은 삭제되며 복구되지 않습니다.'

--- a/front/lib/screen/authentication/setup_user.dart
+++ b/front/lib/screen/authentication/setup_user.dart
@@ -110,33 +110,41 @@ class _SetupUserState extends State<SetupUser> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: basicAppBar(title: '회원가입', backButton: false),
-      body: SingleChildScrollView(
-          child: Center(
-              child: Column(children: [
-        const SizedBox(height: 20),
-        _nicknameSection(),
-        const SizedBox(height: 20),
-        _buildSelectedCharacter(),
-        const SizedBox(height: 20),
-        _buildCharacterList(),
-        const SizedBox(height: 20),
-        Container(
-            width: getDeviceWidth(context) * 0.9,
-            child:
-                fullyRoundedRectangleButton(colors.blockColor, '완료', () async {
-              if (_formKey.currentState!.validate()) {
-                UserModel userData = UserModel(
-                    id: user!.uid,
-                    nickname: _nickname.text,
-                    character: _selectedCharacter!.split('/')[3].split('.')[0],
-                    attendanceStreak: null,
-                    lastAccessDate: null,
-                    lastPracticeScript: null,
-                    voiceUrls: {'long': "", 'middle': "", 'short': ""});
-                Get.to(() => GetUserVoice(userData: userData));
-              }
-            }))
-      ]))),
-    );
+      body: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: ListView(
+          children: [
+            Center(
+              child: Column(
+                children: [
+                  const SizedBox(height: 20),
+                  _nicknameSection(),
+                  const SizedBox(height: 20),
+                  _buildSelectedCharacter(),
+                  const SizedBox(height: 20),
+                  _buildCharacterList(),
+                  const SizedBox(height: 20),
+                  Container(
+                    width: getDeviceWidth(context) * 0.9,
+                    child:
+                        fullyRoundedRectangleButton(colors.blockColor, '완료', () async {
+                      if (_formKey.currentState!.validate()) {
+                        UserModel userData = UserModel(
+                            id: user!.uid,
+                            nickname: _nickname.text,
+                            character: _selectedCharacter!.split('/')[3].split('.')[0],
+                            attendanceStreak: null,
+                            lastAccessDate: null,
+                            lastPracticeScript: null,
+                            voiceUrls: {'long': "", 'middle': "", 'short': ""});
+                        Get.to(() => GetUserVoice(userData: userData));
+                      }
+                    }))
+                ])
+            )
+        ]),
+    ));
   }
 }

--- a/front/lib/screen/script/create_user_script/controller/content_controller.dart
+++ b/front/lib/screen/script/create_user_script/controller/content_controller.dart
@@ -3,16 +3,12 @@ import 'package:get/get.dart';
 
 class UserScriptContentController extends GetxController {
   List<TextEditingController>? textEditingControllerList;
-  final List<String> sentenceList;
-  UserScriptContentController(this.sentenceList);
 
-  @override
-  void onInit() {
+  void updateContent(List<String> sentenceList) {
     textEditingControllerList = [
       for (String sentence in sentenceList)
         TextEditingController(text: sentence)
     ];
-    super.onInit();
   }
 
   void addController() {

--- a/front/lib/screen/script/create_user_script/create_user_script.dart
+++ b/front/lib/screen/script/create_user_script/create_user_script.dart
@@ -62,16 +62,27 @@ class _CreateUserScriptState extends State<CreateUserScript> {
 
   @override
   Widget build(BuildContext context) {
+    final contentController = Get.put(UserScriptContentController());
+
     return Scaffold(
       appBar: basicAppBar(title: '나만의 대본 만들기'),
       body: Stack(
         children: [
-          Column(
-            children: [
-              TitleSection(titleController: _title, formKey: _titleKey),
-              CategorySection(onCategorySelected: _handleCategorySelected),
-              ContentSection(contentController: _content, formKey: _contentKey)
-          ]),
+          GestureDetector(
+            onTap: () {
+              FocusScope.of(context).unfocus();
+            },
+            child: ListView(
+              children: [
+                  Column(
+                    children: [
+                      TitleSection(titleController: _title, formKey: _titleKey),
+                      CategorySection(onCategorySelected: _handleCategorySelected),
+                      ContentSection(contentController: _content, formKey: _contentKey)
+                  ]),
+                ]
+            )
+          ),
           bottomButtons(
             getDeviceWidth(context), 
             outlinedRoundedRectangleButton('AI로 생성하기', () {
@@ -86,7 +97,7 @@ class _CreateUserScriptState extends State<CreateUserScript> {
 
               if (_titleKey.currentState!.validate() & validCategory & _contentKey.currentState!.validate()) {
                 List<String>? sentenceList = splitContent(_content.text);
-                Get.put(UserScriptContentController(sentenceList));
+                contentController.updateContent(sentenceList);
 
                 Get.to(() => AdjustUserScript(
                   title: _title.text, 

--- a/front/lib/screen/search/search_script.dart
+++ b/front/lib/screen/search/search_script.dart
@@ -67,7 +67,12 @@ class _SearchScriptState extends State<SearchScript> {
               ])
             ),
             Flexible(
-              child: SearchTabs(query: query.text),
+              child: GestureDetector(
+                onTap: () {
+                  FocusScope.of(context).unfocus();
+                },
+                child: SearchTabs(query: query.text),
+              )
             )
         ])
     ));

--- a/front/lib/widget/warning_dialog.dart
+++ b/front/lib/widget/warning_dialog.dart
@@ -24,7 +24,7 @@ class WarningDialog extends StatelessWidget {
               fontWeight: FontWeight.w500),
         ),
         actions: [
-            warningObject == 'category'
+            warningObject == 'category' || warningObject == 'content'
             ? fullyRoundedRectangleButton(colors.buttonColor, '확인', () {
                 Navigator.of(context).pop();
             })


### PR DESCRIPTION
## Feature Description
- 사용자 대본 내용 조정 화면에서 대본 생성 화면으로 돌아와 내용을 수정한 후, 다시 조정 화면으로 넘어갔을 때 변경한 내용이 반영되지 않는 문제를 해결했습니다.
- 대본 조정 페이지에서 content block이 하나라도 비어있을 시, warning dialog를 보여주도록 변경했습니다.
- 사용자 편의성을 위해 텍스트 입력 시, 입력창/키보드 외 주변 화면을 누르면 키보드가 내려가도록 수정했습니다. (SetupUser, Search, CreateUserScript, AdjustUserScript) 

## Tasks to Complete
- [x] 대본 내용 조정 화면에서 변경된 내용이 반영되지 않는 문제 해결
- [x] content block 비어있을 때, warning dialog 호출
- [x] 텍스트 입력 시 unfocus 추가

## Additional Resources (Optional)
