### PR TITLE
[CD-235] GithubPages docs 추가

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: capstone-2024-08
 description: 아나운서 준비생을 위한 맞춤형 AI 스피치 연습 애플리케이션, Loro(로로)
-show_downloads: false
+show_downloads: true
 google_analytics:
 theme: jekyll-theme-cayman

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,8 +22,7 @@
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
       {% endif %}
       {% if site.show_downloads %}
-        <a href="{{ site.github.zip_url }}" class="btn">중간발표 ppt</a>
-        <a href="{{ site.github.tar_url }}" class="btn">UI Wireframe</a>
+        <a href="../resources/capstone-08-final-report.pdf" class="btn">중간발표 ppt</a>
       {% endif %}
     </header>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,7 +22,7 @@
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
       {% endif %}
       {% if site.show_downloads %}
-        <a href="../resources/capstone-08-final-report.pdf" class="btn">중간발표 ppt</a>
+        <a href="/capstone-2024-08/resources/capstone-08-final-report.pdf" class="btn">Documentation</a>
       {% endif %}
     </header>
 


### PR DESCRIPTION
## Feature Description
- 최종 보고서를 가장 위로 배치 

TO-BE: https://why-arong.github.io/capstone-2024-08/

버튼 이름이 현재 Documentation 인데 좋은 이름 있으면 추천해주세요!

